### PR TITLE
Add more metadata from Chart.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ annotations:
   operators.operatorframework.io.bundle.channels.v1: "beta,stable"
   operators.operatorframework.io.bundle.channel.default.v1: "stable"
 ```
+
+Tool also supports [artifacthub.io/*](https://artifacthub.io/docs/topics/annotations/helm/) 
+metadata in Chart.yaml provided as annotations. In case there is a conflict of metadata coming 
+from directory scan and metadata that are explicitly mentioned in Chart.yaml, this can be 
+controlled by using `--helm-chart-overrides` switch. 

--- a/internal/manifests/helm.go
+++ b/internal/manifests/helm.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -13,12 +14,15 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 // HelmMetadata writes metadata parsed from a Helm chart to ClusterServiceVersion.
 type HelmMetadata struct {
-	ChartFilePath string
-	Version       string
+	ChartFilePath      string
+	Version            string
+	HelmChartOverrides bool
 }
 
 // Embed reads Chart.yaml and puts all the matching available metadata into
@@ -57,8 +61,153 @@ func (hm *HelmMetadata) Embed(ctx context.Context, csv *v1alpha1.ClusterServiceV
 			Email: c.Maintainers[i].Email,
 		}
 	}
+	csv.Spec.Links = getLinks(c)
 	csv.Spec.Keywords = c.Keywords
+	if csv.GetAnnotations() == nil {
+		csv.SetAnnotations(map[string]string{})
+	}
+	if c.Annotations != nil {
+		err = enrichWithArtifacthubAnns(c.Annotations, csv, hm.HelmChartOverrides)
+	}
+
+	return err
+}
+
+func getLinks(c *chart.Metadata) []v1alpha1.AppLink {
+	links := []v1alpha1.AppLink{}
+	if c.Home != "" {
+		links = append(links, v1alpha1.AppLink{
+			Name: "Home",
+			URL:  c.Home,
+		})
+	}
+	if len(c.Sources) > 1 {
+		for i, s := range c.Sources {
+			links = append(links, v1alpha1.AppLink{
+				Name: fmt.Sprintf("Source %d", i+1),
+				URL:  s,
+			})
+		}
+	} else if len(c.Sources) == 1 {
+		links = append(links, v1alpha1.AppLink{
+			Name: "Source",
+			URL:  c.Sources[0],
+		})
+	}
+
+	return links
+}
+
+// Using fields defined in https://artifacthub.io/docs/topics/annotations/helm/
+func enrichWithArtifacthubAnns(ann map[string]string, csv *v1alpha1.ClusterServiceVersion, overrides bool) error {
+	if ann["artifacthub.io/operator"] != "true" {
+		return nil
+	}
+
+	// capabilities
+	if val, ok := ann["artifacthub.io/operatorCapabilities"]; ok {
+		csv.Annotations["capabilities"] = val
+	}
+	// maintainers
+	hm, errM := unmarshalField(ann, "artifacthub.io/maintainers", []v1alpha1.Maintainer{})
+	if errM != nil {
+		return errM
+	}
+	if hm != nil && overrides {
+		csv.Spec.Maintainers = hm.([]v1alpha1.Maintainer)
+	}
+
+	// crd definitions
+	err := enrichCrds(ann, csv, overrides)
+	if err != nil {
+		return err
+	}
+
+	// crd examples
+	if val, ok := ann["artifacthub.io/crdsExamples"]; ok {
+		json, err := yaml.YAMLToJSON([]byte(val))
+		if err != nil {
+			return errors.Wrap(err, "cannot unmarshal artifacthub.io/crdsExamples in Chart.yaml")
+		}
+		csv.Annotations["alm-examples"] = string(json)
+	}
+
 	return nil
+}
+
+func enrichCrds(ann map[string]string, csv *v1alpha1.ClusterServiceVersion, overrides bool) error {
+	hCrdV, errC := unmarshalField(ann, "artifacthub.io/crds", []v1alpha1.CRDDescription{})
+	if errC != nil {
+		return errC
+	}
+	if hCrdV != nil {
+		hCrd := hCrdV.([]v1alpha1.CRDDescription)
+		var err error
+		csv.Spec.CustomResourceDefinitions.Owned, err = mergeCrds(csv.Spec.CustomResourceDefinitions.Owned, hCrd, overrides)
+		if err != nil {
+			return errors.Wrap(err, "cannot merge owned crds (coming from helm chart w/ those coming from the filesystem)")
+		}
+	}
+	return nil
+}
+
+// merge the CRDDescription slice coming from filesystem traversal with the slice coming from Chart.yaml
+// using strategic merge (the function doesn't work with slices directly therefore we need to hook it on
+// CustomResourceDefinitions struct)
+func mergeCrds(orig, fromHelm []v1alpha1.CRDDescription, overrides bool) ([]v1alpha1.CRDDescription, error) {
+	if orig != nil {
+		if overrides {
+			return fromHelm, nil
+		}
+		origCrds, helmCrds := &v1alpha1.CustomResourceDefinitions{}, &v1alpha1.CustomResourceDefinitions{}
+		origCrds.Owned, helmCrds.Owned = orig, fromHelm
+		origCrdsJSON, _ := json.Marshal(origCrds)
+		helmCrdsJSON, _ := json.Marshal(fromHelm)
+		if origCrdsJSON == nil || helmCrdsJSON == nil {
+			return nil, errors.New("can't marshal to json")
+		}
+		if c, e := mergepatch.HasConflicts(origCrds, helmCrds); c || e != nil {
+			return fromHelm, nil
+		}
+		patchBytes, e1 := strategicpatch.CreateTwoWayMergePatch(origCrdsJSON, helmCrdsJSON, v1alpha1.CustomResourceDefinitions{})
+
+		if e1 != nil {
+			return nil, errors.Wrap(e1, "cannot calculate patch")
+		}
+		resultBytes, e2 := strategicpatch.StrategicMergePatch(origCrdsJSON, patchBytes, orig)
+		if e2 != nil {
+			return nil, errors.Wrap(e2, "cannot apply patch")
+		}
+		result := &v1alpha1.CustomResourceDefinitions{}
+		err := json.Unmarshal(resultBytes, result)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot unmarshal the result")
+		}
+		return result.Owned, nil
+	}
+	return fromHelm, nil
+}
+
+func unmarshalField(ann map[string]string, key string, t interface{}) (interface{}, error) {
+	if val, ok := ann[key]; ok {
+		switch typ := t.(type) {
+		case []v1alpha1.CRDDescription:
+			helmVal := &[]v1alpha1.CRDDescription{}
+			if err := yaml.Unmarshal([]byte(val), helmVal); err != nil {
+				return nil, errors.Wrap(err, fmt.Sprintf("cannot unmarshal %s as type %T in Chart.yaml", key, typ))
+			}
+			return *helmVal, nil
+		case []v1alpha1.Maintainer:
+			helmVal := &[]v1alpha1.Maintainer{}
+			if err := yaml.Unmarshal([]byte(val), helmVal); err != nil {
+				return nil, errors.Wrap(err, fmt.Sprintf("cannot unmarshal %s as type %T in Chart.yaml", key, typ))
+			}
+			return *helmVal, nil
+		default:
+			return nil, errors.New(fmt.Sprintf("Unsupported type: %T", typ))
+		}
+	}
+	return nil, nil
 }
 
 func getIconData(ctx context.Context, url string) (v1alpha1.Icon, error) {


### PR DESCRIPTION
Adds more metadata from Chart.yaml. Namely:

- links
- capabilities
- maintainers
- crd examples
- crd metadata

(last 4 comes from artifacthub.io/* annotations)
Adding also new boolean switch that controls the conflict resolution (in case there is different info coming from helm chart and filesystem).


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>