### PR TITLE
Add a way to set csv.spec.replaces field

### DIFF
--- a/cmd/olm-bundle/main.go
+++ b/cmd/olm-bundle/main.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -22,6 +23,7 @@ type olmBundleCLI struct {
 	OutputDir          string `help:"Output directory to save the OLM bundle files." type:"path" required:""`
 	ExtraResourcesDir  string `help:"Extra resources you would like to add to the OLM bundle." type:"path"`
 	Version            string `help:"Version of the generated bundle. If not provided, value from Chart.yaml will be used"`
+	ReplacesVersion    string `help:"Version of the operator that this new bundle should replace. This should be empty for the fist release (~CSV.spec.replaces)"`
 	HelmChartOverrides bool   `help:"If set, metadata read from Chart.yaml will take precedence over those taken from the directory scan (in case of conflict)"`
 }
 
@@ -75,6 +77,12 @@ func main() {
 	}
 	for k, v := range ann {
 		resultCSV.GetAnnotations()[k] = v
+	}
+
+	// Sets the csv.Spec.Replaces that's needed for OLM to build the dependency DAG
+	if cli.ReplacesVersion != "" {
+		name := resultCSV.Name[:strings.IndexByte(resultCSV.Name, '.')]
+		resultCSV.Spec.Replaces = fmt.Sprintf("%s.%s", name, cli.ReplacesVersion)
 	}
 
 	// Validate and write the files to the disk.


### PR DESCRIPTION
For subsequent contributions to [OLM upstream repo](https://github.com/k8s-operatorhub/community-operators) the `replaces` field needs to be set in order for the CI checks to pass. They check the upgrade path. The filed needs to be empty for the very first contribution.

details:
https://docs.openshift.com/container-platform/4.2/operators/understanding_olm/olm-understanding-olm.html#olm-upgrades-example-upgrade-path_olm-understanding-olm