### PR TITLE
Include the service account yamls only if requested

### DIFF
--- a/cmd/olm-bundle/main.go
+++ b/cmd/olm-bundle/main.go
@@ -25,6 +25,7 @@ type olmBundleCLI struct {
 	Version            string `help:"Version of the generated bundle. If not provided, value from Chart.yaml will be used"`
 	ReplacesVersion    string `help:"Version of the operator that this new bundle should replace. This should be empty for the fist release (~CSV.spec.replaces)"`
 	HelmChartOverrides bool   `help:"If set, metadata read from Chart.yaml will take precedence over those taken from the directory scan (in case of conflict)"`
+	IncludeSA          bool   `help:"If set, manifests with service account definitions will be included in the bundle"`
 }
 
 func main() {
@@ -93,6 +94,7 @@ func main() {
 	}
 	out[len(out)-1] = resultCSV
 	b := &writer.Bundle{
+		IncludeSA:  cli.IncludeSA,
 		PackageDir: cli.OutputDir,
 		Manifests:  out,
 		Metadata: writer.Metadata{

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -15,6 +15,7 @@ import (
 
 // Bundle represents the final state that will be written to disk.
 type Bundle struct {
+	IncludeSA  bool
 	PackageDir string
 	Manifests  []client.Object
 	Metadata   Metadata
@@ -76,7 +77,11 @@ func (b *Bundle) writeManifests(dir string) error {
 	for _, m := range b.Manifests {
 		// Kind is made lower-case to pass integration tests in OLM repositories,
 		// it is not a requirement for other tools in OLM ecosystem.
-		name := fmt.Sprintf("%s.%s.yaml", cleanName(m.GetName()), strings.ToLower(m.GetObjectKind().GroupVersionKind().Kind))
+		kind := m.GetObjectKind().GroupVersionKind().Kind
+		if !b.IncludeSA && kind == "ServiceAccount" {
+			continue
+		}
+		name := fmt.Sprintf("%s.%s.yaml", cleanName(m.GetName()), strings.ToLower(kind))
 		o, err := yaml.Marshal(m)
 		if err != nil {
 			return errors.Wrap(err, "cannot marshal object into YAML")


### PR DESCRIPTION
Related to https://github.com/k8gb-io/k8gb/issues/866

From some reason the OLM bundle can't contain the SA definition (we had it there before and CI was [ok with that](https://github.com/k8s-operatorhub/community-operators/tree/main/operators/k8gb/0.8.6/manifests)). However, the olm bundles of two last releases of k8gb `0.8.8` & `0.9.0` were not merged automatically, because their CI failed on this. I fixed this manually by removing the SA yamls (1 for k8gb and 1 for coredns), but it would be pain to do that for each release, hence this PR.

might be related to this, but I am not 100% sure:
https://github.com/operator-framework/operator-lifecycle-manager/pull/2034/files

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>